### PR TITLE
Enabling External NodeStores for path translation

### DIFF
--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -269,6 +269,10 @@ typedef UA_Int32 (*UA_ExternalNodeStore_browseNodes)
  UA_UInt32 *indices, UA_UInt32 indicesSize, UA_UInt32 requestedMaxReferencesPerNode,
  UA_BrowseResult *browseResults, UA_DiagnosticInfo *diagnosticInfos);
 
+typedef UA_Int32 (*UA_ExternalNodeStore_translateBrowsePathsToNodeIds)
+(void *ensHandle, const UA_RequestHeader *requestHeader, UA_BrowsePath *browsePath,
+ UA_UInt32 *indices, UA_UInt32 indicesSize, UA_BrowsePathResult *browsePathResults, UA_DiagnosticInfo *diagnosticInfos);
+
 typedef UA_Int32 (*UA_ExternalNodeStore_delete)(void *ensHandle);
 
 typedef struct UA_ExternalNodeStore {
@@ -278,6 +282,7 @@ typedef struct UA_ExternalNodeStore {
 	UA_ExternalNodeStore_writeNodes writeNodes;
 	UA_ExternalNodeStore_readNodes readNodes;
 	UA_ExternalNodeStore_browseNodes browseNodes;
+	UA_ExternalNodeStore_translateBrowsePathsToNodeIds translateBrowsePathsToNodeIds;
 	UA_ExternalNodeStore_addReferences addReferences;
 	UA_ExternalNodeStore_deleteReferences deleteReferences;
 	UA_ExternalNodeStore_delete destroy;

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -365,7 +365,7 @@ void Service_TranslateBrowsePathsToNodeIds(UA_Server *server, UA_Session *sessio
                                            const UA_TranslateBrowsePathsToNodeIdsRequest *request,
                                            UA_TranslateBrowsePathsToNodeIdsResponse *response) {
     size_t size = request->browsePathsSize;
-	if(request->browsePathsSize <= 0) {
+	if(size <= 0) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNOTHINGTODO;
         return;
     }


### PR DESCRIPTION
Up to now the service translateBrowsePathToNodeId was always called on the internal nodeStore. When only external nodeStores were present this resulted in a NULL-Pointer deref (the ns-Pointer in the server-strucutre is not set as there is no internal nodeStore).
If the starting point for a path translation lies within an external namespace, it makes sense to call this namespace's translate function. Therefore, I added the translateBrowsePathToNodeId function to the external nodeStore function pointer table and implemented the check for external namespaces for the path starting points, calling the external function when necessarry. The looping and checks are analog to the other services.