### PR TITLE
Improve compatibility for old / uclibc systems endian conversion

### DIFF
--- a/src/ua_config.h.in
+++ b/src/ua_config.h.in
@@ -31,11 +31,11 @@
 
 /*	Define your own htoleXX and leXXtoh here if needed.
 	Otherwise the ones defined in endian.h are used		*/
-//	#define htole16(x)	
-//	#define htole32(x)
-//	#define htole64(x)
-//	#define le16toh(x)
-//	#define le32toh(x)
-//	#define le64toh(x)
+//	#define htole16(x)	{...}(x)
+//	#define htole32(x)	{...}(x)
+//	#define htole64(x)	{...}(x)
+//	#define le16toh(x)	{...}(x)
+//	#define le32toh(x)	{...}(x)
+//	#define le64toh(x)	{...}(x)
 
 #endif /* UA_CONFIG_H_ */

--- a/src/ua_config.h.in
+++ b/src/ua_config.h.in
@@ -29,4 +29,13 @@
 #  endif
 #endif
 
+/*	Define your own htoleXX and leXXtoh here if needed.
+	Otherwise the ones defined in endian.h are used		*/
+//	#define htole16(x)	
+//	#define htole32(x)
+//	#define htole64(x)
+//	#define le16toh(x)
+//	#define le32toh(x)
+//	#define le64toh(x)
+
 #endif /* UA_CONFIG_H_ */

--- a/src/ua_util.h
+++ b/src/ua_util.h
@@ -10,8 +10,6 @@
 #endif
 #ifndef _POSIX_SOURCE
 # define _POSIX_SOURCE
-#endif
-#ifndef _POSIX_C_SOURCE
 # define _POSIX_C_SOURCE 199309L
 #endif
 #ifndef _BSD_SOURCE
@@ -31,6 +29,8 @@
 
 #ifdef _WIN32
 # include <malloc.h>
+#else
+# include <alloca.h>
 #endif
 
 #define UA_NULL ((void *)0)
@@ -50,14 +50,9 @@
 #define UA_memset(ptr, value, size) memset(ptr, value, size)
 
 #ifdef _WIN32
-    # define UA_alloca(SIZE) _alloca(SIZE)
+# define UA_alloca(SIZE) _alloca(SIZE)
 #else
- #ifdef __GNUC__
-    # define UA_alloca(size)   __builtin_alloca (size)
- #else
-    # include <alloca.h>
-    # define UA_alloca(SIZE) alloca(SIZE)
- #endif
+# define UA_alloca(SIZE) alloca(SIZE)
 #endif
 
 /********************/
@@ -75,7 +70,9 @@
 # undef SLIST_ENTRY
 # define RAND(SEED) (UA_UInt32)rand()
 #else
-# include <endian.h>
+# if !(defined htole16 && defined htole32 && defined htole64 && defined le16toh && defined le32toh && defined le64toh)
+#  include <endian.h>
+# endif
 # include <sys/time.h>
 # define RAND(SEED) (UA_UInt32)rand_r(SEED)
 #endif

--- a/src/ua_util.h
+++ b/src/ua_util.h
@@ -72,6 +72,18 @@
 #else
 # if !(defined htole16 && defined htole32 && defined htole64 && defined le16toh && defined le32toh && defined le64toh)
 #  include <endian.h>
+#  if !(defined htole16 && defined htole32 && defined htole64 && defined le16toh && defined le32toh && defined le64toh)
+#   if ( __BYTE_ORDER != __LITTLE_ENDIAN )
+#    error "Host byte order is not little-endian and no appropriate conversion functions are defined. (Have a look at ua_config.h)"
+#   else
+#    define htole16(x) x
+#    define htole32(x) x
+#    define htole64(x) x
+#    define le16toh(x) x
+#    define le32toh(x) x
+#    define le64toh(x) x
+#   endif
+#  endif
 # endif
 # include <sys/time.h>
 # define RAND(SEED) (UA_UInt32)rand_r(SEED)

--- a/src/ua_util.h
+++ b/src/ua_util.h
@@ -10,6 +10,8 @@
 #endif
 #ifndef _POSIX_SOURCE
 # define _POSIX_SOURCE
+#endif
+#ifndef _POSIX_C_SOURCE
 # define _POSIX_C_SOURCE 199309L
 #endif
 #ifndef _BSD_SOURCE
@@ -29,8 +31,6 @@
 
 #ifdef _WIN32
 # include <malloc.h>
-#else
-# include <alloca.h>
 #endif
 
 #define UA_NULL ((void *)0)
@@ -50,9 +50,14 @@
 #define UA_memset(ptr, value, size) memset(ptr, value, size)
 
 #ifdef _WIN32
-# define UA_alloca(SIZE) _alloca(SIZE)
+    # define UA_alloca(SIZE) _alloca(SIZE)
 #else
-# define UA_alloca(SIZE) alloca(SIZE)
+ #ifdef __GNUC__
+    # define UA_alloca(size)   __builtin_alloca (size)
+ #else
+    # include <alloca.h>
+    # define UA_alloca(SIZE) alloca(SIZE)
+ #endif
 #endif
 
 /********************/


### PR DESCRIPTION
if there are no appropriate functions defined and the endianness does not fit from the start an error is thrown.