### PR TITLE
The use of ${PYTHON_EXECUTABLE} is more generic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(open62541 C)
 FIND_PACKAGE(PythonInterp REQUIRED)
 
 # Find Python-lxml
-execute_process ( COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT EXISTS "${PYTHON_SITE_PACKAGES}/lxml")
     message( FATAL_ERROR "Python-lxml is not installed.")
 endif()


### PR DESCRIPTION
It is possible that python is not included in the PATH variable.