### PR TITLE
removing init from the decodeBinary -> brings up to 10% of performance

### DIFF
--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -579,6 +579,8 @@ UA_StatusCode UA_EXPORT UA_copy(const void *src, void *dst, const UA_DataType *d
  */
 void UA_EXPORT UA_deleteMembers(void *p, const UA_DataType *dataType);
 
+void UA_EXPORT UA_deleteMembersUntil(void *p, const UA_DataType *dataType, UA_Int32 lastMember);
+
 /**
  * Deletes (frees) a variable and all of its content.
  *

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1117,11 +1117,18 @@ UA_StatusCode UA_copy(const void *src, void *dst, const UA_DataType *dataType) {
 }
 
 void UA_deleteMembers(void *p, const UA_DataType *dataType) {
+    UA_deleteMembersUntil(p, dataType, -1);
+}
+
+void UA_deleteMembersUntil(void *p, const UA_DataType *dataType, UA_Int32 lastMember) {
     uintptr_t ptr = (uintptr_t)p;
     if(dataType->fixedSize)
         return;
     UA_Byte membersSize = dataType->membersSize;
     for(size_t i=0;i<membersSize; i++) {
+        if(lastMember > -1 && (UA_Int32)i > lastMember){
+            return;
+        }
         const UA_DataTypeMember *member = &dataType->members[i];
         const UA_DataType *memberType;
         if(member->namespaceZero)
@@ -1185,7 +1192,11 @@ void UA_deleteMembers(void *p, const UA_DataType *dataType) {
             break;
         default:
             // QualifiedName, LocalizedText and strings are treated as structures, also
-            UA_deleteMembers((void*)ptr, memberType);
+            if(lastMember > -1){
+                UA_deleteMembersUntil((void*)ptr, memberType, lastMember-i);
+            }
+            else
+                UA_deleteMembers((void*)ptr, memberType);
         }
         ptr += memberType->memSize;
     }


### PR DESCRIPTION
the cleanup needs to trace the position of the last allocation + calloc in array decoding
no valgrind varnings or memleaks, tests do pass

however, I am still not sure... @jpfr review needed