### PR TITLE
Memory leak in ServerNetworkLayerTCP_getJobs function

### DIFF
--- a/examples/networklayer_tcp.c
+++ b/examples/networklayer_tcp.c
@@ -354,6 +354,12 @@ static UA_Int32 ServerNetworkLayerTCP_getJobs(UA_ServerNetworkLayer *nl, UA_Job 
         j++;
     }
 
+    if (j == 0)
+    {
+    	free(js);
+    	js = NULL;
+    }
+
     *jobs = js;
     return j;
 }

--- a/src/server/ua_server_addressspace.c
+++ b/src/server/ua_server_addressspace.c
@@ -408,6 +408,7 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
     
     if (createdNodeId != UA_NULL)
       UA_NodeId_copy(&addRes.addedNodeId, createdNodeId);
+    UA_AddNodesResult_deleteMembers(&addRes);
     
     /* create InputArguments */
     UA_NodeId argId = UA_NODEID_NUMERIC(nodeId.namespaceIndex, 0); 
@@ -419,7 +420,6 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
     inputArgumentsVariableNode->valueRank = 1;
     UA_Variant_setArrayCopy(&inputArgumentsVariableNode->value.variant, inputArguments,
                             inputArgumentsSize, &UA_TYPES[UA_TYPES_ARGUMENT]);
-    UA_AddNodesResult_deleteMembers(&addRes);
     addRes = UA_Server_addNode(server, (UA_Node*)inputArgumentsVariableNode, methodExpandedNodeId,
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY));
     if(addRes.statusCode != UA_STATUSCODE_GOOD) {
@@ -427,6 +427,7 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
         // TODO Remove node
         return addRes.statusCode;
     }
+    UA_AddNodesResult_deleteMembers(&addRes);
 
     /* create OutputArguments */
     argId = UA_NODEID_NUMERIC(nodeId.namespaceIndex, 0);
@@ -438,7 +439,6 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
     outputArgumentsVariableNode->valueRank = 1;
     UA_Variant_setArrayCopy(&outputArgumentsVariableNode->value.variant, outputArguments,
                             outputArgumentsSize, &UA_TYPES[UA_TYPES_ARGUMENT]);
-    UA_AddNodesResult_deleteMembers(&addRes);
     addRes = UA_Server_addNode(server, (UA_Node*)outputArgumentsVariableNode, methodExpandedNodeId,
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY));
     UA_ExpandedNodeId_deleteMembers(&methodExpandedNodeId);

--- a/src/server/ua_server_addressspace.c
+++ b/src/server/ua_server_addressspace.c
@@ -427,9 +427,7 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
         // TODO Remove node
         return addRes.statusCode;
     }
-    if (createdNodeId != UA_NULL)
-      UA_NodeId_copy(&addRes.addedNodeId, createdNodeId);
-    
+
     /* create OutputArguments */
     argId = UA_NODEID_NUMERIC(nodeId.namespaceIndex, 0);
     UA_VariableNode *outputArgumentsVariableNode  = UA_VariableNode_new();

--- a/src/server/ua_server_addressspace.c
+++ b/src/server/ua_server_addressspace.c
@@ -419,6 +419,7 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
     inputArgumentsVariableNode->valueRank = 1;
     UA_Variant_setArrayCopy(&inputArgumentsVariableNode->value.variant, inputArguments,
                             inputArgumentsSize, &UA_TYPES[UA_TYPES_ARGUMENT]);
+    UA_AddNodesResult_deleteMembers(&addRes);
     addRes = UA_Server_addNode(server, (UA_Node*)inputArgumentsVariableNode, methodExpandedNodeId,
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY));
     if(addRes.statusCode != UA_STATUSCODE_GOOD) {
@@ -439,12 +440,14 @@ UA_Server_addMethodNode(UA_Server *server, const UA_QualifiedName browseName, UA
     outputArgumentsVariableNode->valueRank = 1;
     UA_Variant_setArrayCopy(&outputArgumentsVariableNode->value.variant, outputArguments,
                             outputArgumentsSize, &UA_TYPES[UA_TYPES_ARGUMENT]);
+    UA_AddNodesResult_deleteMembers(&addRes);
     addRes = UA_Server_addNode(server, (UA_Node*)outputArgumentsVariableNode, methodExpandedNodeId,
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY));
     UA_ExpandedNodeId_deleteMembers(&methodExpandedNodeId);
     if(addRes.statusCode != UA_STATUSCODE_GOOD)
         // TODO Remove node
         retval = addRes.statusCode;
+    UA_AddNodesResult_deleteMembers(&addRes);
     return retval;
 }
 #endif

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -37,7 +37,6 @@ void UA_Subscription_deleteMembers(UA_Subscription *subscription, UA_Server *ser
     
     // Delete unpublished Notifications
     LIST_FOREACH_SAFE(not, &subscription->unpublishedNotifications, listEntry, tmp_not) {
-        LIST_REMOVE(not, listEntry);
         Subscription_deleteUnpublishedNotification(not->notification->sequenceNumber, subscription);
     }
     


### PR DESCRIPTION
ServerNetworkLayerTCP_getJobs function allocate js variable (UA_Job type) but sometime, for some reasons return 0.

In this case UA_Server_run_mainloop function don't free js variable allocated by ServerNetworkLayerTCP_getJobs.

Best regards,

Thomas

fixes #326