### PR TITLE
update server.c

### DIFF
--- a/examples/server.c
+++ b/examples/server.c
@@ -331,9 +331,13 @@ int main(int argc, char** argv) {
    outputArguments.valueRank = -1;
 
    UA_NodeId methodId; // Retrieve the actual ID if this node if a random id as in UA_NODEID_NUMERIC(1,0) is used
-   UA_Server_addMethodNode(server, UA_QUALIFIEDNAME(1,"ping"), UA_NODEID_NUMERIC(1,62541),
-                           UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                           &getMonitoredItems, 1, &inputArguments, 1, &outputArguments, &methodId);
+   UA_StatusCode retvalM = UA_Server_addMethodNode(server, UA_QUALIFIEDNAME(1,"ping"), UA_NODEID_NUMERIC(1,62541),
+                                                  UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                                  &getMonitoredItems, 1, &inputArguments, 1, &outputArguments, &methodId);
+                                                  
+   if (retvalM == UA_STATUSCODE_GOOD)
+      UA_NodeId_deleteMembers(&methodId);
+                                                  
 #endif
 	//start server
 	UA_StatusCode retval = UA_Server_run(server, 1, &running); //blocks until running=false


### PR DESCRIPTION
deleteMembers of methodId after call of UA_Server_addMethodNode

If  UA_NodeId_deleteMembers is not called : can cause memory leak if use UA_NODEID_STRING(1,"somthing") insted of UA_NODEID_NUMERIC(1,62541)