### PR TITLE
Update ua_client.c, fixes #323

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -693,8 +693,8 @@ UA_StatusCode UA_Client_removeSubscription(UA_Client *client, UA_UInt32 subscrip
     request.subscriptionIds = (UA_UInt32 *) UA_malloc(sizeof(UA_UInt32));
     *(request.subscriptionIds) = sub->SubscriptionID;
     
-    UA_Client_MonitoredItem *mon;
-    LIST_FOREACH(mon, &(sub->MonitoredItems), listEntry) {
+    UA_Client_MonitoredItem *mon, *tmpmon;
+    LIST_FOREACH_SAFE(mon, &(sub->MonitoredItems), listEntry, tmpmon) {
         retval |= UA_Client_unMonitorItemChanges(client, sub->SubscriptionID, mon->MonitoredItemId);
     }
     if (retval != UA_STATUSCODE_GOOD){
@@ -793,8 +793,8 @@ UA_StatusCode UA_Client_unMonitorItemChanges(UA_Client *client, UA_UInt32 subscr
     if (sub == NULL)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     
-    UA_Client_MonitoredItem *mon;
-    LIST_FOREACH(mon, &(sub->MonitoredItems), listEntry) {
+    UA_Client_MonitoredItem *mon, *tmpmon;
+    LIST_FOREACH_SAFE(mon, &(sub->MonitoredItems), listEntry, tmpmon) {
         if (mon->MonitoredItemId == monitoredItemId)
             break;
     }


### PR DESCRIPTION
Remove 

==32297== Invalid read of size 4
==32297==    at 0x40579B1: UA_Client_removeSubscription (open62541.c:11824)
==32297==    by 0x8049515: main (client.c:131)
==32297==  Address 0x42fa1c8 is 56 bytes inside a block of size 64 free'd
==32297==    at 0x402C3D8: free (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==32297==    by 0x4057F04: UA_Client_unMonitorItemChanges (open62541.c:11951)
==32297==    by 0x40579AA: UA_Client_removeSubscription (open62541.c:11825)
==32297==    by 0x8049515: main (client.c:131)
==32297== 

see : https://github.com/acplt/open62541/issues/323