### PR TITLE
Updates to compile Python and Lua bindings

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ENABLE_BINDING_LUA)
     set_target_properties(open62541-lua PROPERTIES COMPILE_FLAGS "-Wno-error")
     target_include_directories(open62541-lua PUBLIC ${LUA_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/include
                                                     ${PROJECT_BINARY_DIR}/src_generated)
-    target_link_libraries(open62541-lua open62541-static)
+    target_link_libraries(open62541-lua open62541 lua)
     set_target_properties(open62541-lua PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lua
                                                    OUTPUT_NAME open62541 PREFIX "")
 endif()
@@ -32,7 +32,7 @@ if(ENABLE_BINDING_PYTHON)
     set_target_properties(open62541-python PROPERTIES COMPILE_FLAGS "-Wno-error")
     target_include_directories(open62541-python PUBLIC ${PYTHON_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/include
                                                        ${PROJECT_BINARY_DIR}/src_generated)
-    target_link_libraries(open62541-python open62541-static)
+    target_link_libraries(open62541-python open62541 python)
     set_target_properties(open62541-python PROPERTIES
                                            LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python
                                            OUTPUT_NAME _open62541 PREFIX "")

--- a/bindings/open62541.i
+++ b/bindings/open62541.i
@@ -4,6 +4,25 @@
 #include "ua_server.h"
 %}
 
+#if defined(SWIGPYTHON)
+%{
+/* avoid no previous prototype warning/error */
+#if PY_VERSION_HEX >= 0x03000000
+PyObject*
+#else
+void
+#endif
+SWIG_init (void);
+%}
+#endif
+
+#if defined(SWIGLUA)
+%{
+/* avoid no previous prototype warning/error */
+SWIGEXPORT int SWIG_init (lua_State* L);
+%}
+#endif
+
 %define UA_TYPE_HANDLING_FUNCTIONS_SWIG(TYPE)
     TYPE * TYPE##_new(void);
     void TYPE##_init(TYPE * p);

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -488,9 +488,10 @@ typedef struct UA_ExternalNodeStore {
 	UA_ExternalNodeStore_delete destroy;
 } UA_ExternalNodeStore;
 
-
+#ifdef UA_EXTERNAL_NAMESPACES
 UA_StatusCode UA_EXPORT
 UA_Server_addExternalNamespace(UA_Server *server, UA_UInt16 namespaceIndex, const UA_String *url, UA_ExternalNodeStore *nodeStore);
+#endif /* UA_EXTERNAL_NAMESPACES*/
 /** @} */
 
 #endif /* external nodestore */
@@ -505,23 +506,24 @@ typedef struct arrayOfNodeIds_s {
   UA_NodeId *ids;
 } arrayOfNodeIds;
 
-UA_StatusCode 
+UA_StatusCode UA_EXPORT
 UA_Server_appendInstanceOfSupertype(UA_Server *server, UA_NodeId nodeId, UA_NodeId appendToNodeId, 
                                     arrayOfNodeIds *subtypeRefs, arrayOfNodeIds *componentRefs, 
                                     UA_InstantiationCallback callback, arrayOfNodeIds *instantiatedTypes, 
                                     void *handle);
 
-void UA_Server_addInstanceOf_instatiateChildNode(UA_Server *server, 
+void UA_EXPORT
+UA_Server_addInstanceOf_instatiateChildNode(UA_Server *server, 
                                                  arrayOfNodeIds *subtypeRefs, arrayOfNodeIds *componentRefs, arrayOfNodeIds *typedefRefs,
                                                  UA_NodeId objectRoot, UA_InstantiationCallback callback, void *typeDefNode,
-                                                 UA_Boolean instantiateObjects, arrayOfNodeIds *instantiatedTypes, void *handle) 
-;
+                                                 UA_Boolean instantiateObjects, arrayOfNodeIds *instantiatedTypes, void *handle);
+                                                 
 UA_StatusCode UA_EXPORT
 UA_Server_addInstanceOf(UA_Server *server, UA_NodeId nodeId, const UA_QualifiedName browseName,
                         UA_LocalizedText displayName, UA_LocalizedText description, const UA_NodeId parentNodeId, 
                         const UA_NodeId referenceTypeId, UA_UInt32 userWriteMask, UA_UInt32 writeMask, 
                         const UA_ExpandedNodeId typeDefinition, UA_InstantiationCallback callback, void *handle, 
-                        UA_NodeId *createdNodeId) ;
+                        UA_NodeId *createdNodeId);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -63,13 +63,13 @@ typedef uint32_t UA_UInt32;
 
 /** @brief An integer value between -10 223 372 036 854 775 808 and 9 223 372 036 854 775 807 */
 typedef int64_t UA_Int64;
-#define UA_INT64_MAX 9223372036854775807
-#define UA_INT64_MIN -9223372036854775808
+#define UA_INT64_MAX (int64_t)9223372036854775807
+#define UA_INT64_MIN (int64_t)-9223372036854775808
 
 /** @brief An integer value between 0 and 18 446 744 073 709 551 615. */
 typedef uint64_t UA_UInt64;
-#define UA_UINT64_MAX = 18446744073709551615
-#define UA_UINT64_MIN = 0
+#define UA_UINT64_MAX (int64_t)18446744073709551615
+#define UA_UINT64_MIN (int64_t)0
 
 /** @brief An IEEE single precision (32 bit) floating point value. */
 typedef float UA_Float;
@@ -105,14 +105,16 @@ typedef UA_String UA_XmlElement;
 
 /** @brief An identifier for a node in the address space of an OPC UA Server. */
 /* The shortened numeric types are introduced during encoding. */
+enum UA_NodeIdType {
+    UA_NODEIDTYPE_NUMERIC    = 2,
+    UA_NODEIDTYPE_STRING     = 3,
+    UA_NODEIDTYPE_GUID       = 4,
+    UA_NODEIDTYPE_BYTESTRING = 5
+};
+
 typedef struct {
     UA_UInt16 namespaceIndex; ///< The namespace index of the node
-    enum UA_NodeIdType {
-        UA_NODEIDTYPE_NUMERIC    = 2,
-        UA_NODEIDTYPE_STRING     = 3,
-        UA_NODEIDTYPE_GUID       = 4,
-        UA_NODEIDTYPE_BYTESTRING = 5
-    } identifierType; ///< The type of the node identifier
+    enum UA_NodeIdType identifierType; ///< The type of the node identifier
     union {
         UA_UInt32     numeric;
         UA_String     string;
@@ -257,11 +259,11 @@ UA_TYPE_HANDLING_FUNCTIONS(UA_Guid)
 #define UA_XmlElement_copy UA_String_copy
 UA_TYPE_HANDLING_FUNCTIONS(UA_NodeId)
 UA_TYPE_HANDLING_FUNCTIONS(UA_ExpandedNodeId)
-#define UA_StatusCode_new(p) UA_Int32_new((UA_Int32*)p)
+#define UA_StatusCode_new() UA_Int32_new()
 #define UA_StatusCode_init(p) UA_Int32_init((UA_Int32*)p)
 #define UA_StatusCode_delete(p) UA_Int32_delete((UA_Int32*)p)
 #define UA_StatusCode_deleteMembers(p) UA_Int32_deleteMembers((UA_Int32*)p)
-#define UA_StatusCode_copy(p) UA_Int32_copy((UA_Int32*)p)
+#define UA_StatusCode_copy(p, q) UA_Int32_copy((UA_Int32*)p, (UA_Int32*)q)
 UA_TYPE_HANDLING_FUNCTIONS(UA_QualifiedName)
 UA_TYPE_HANDLING_FUNCTIONS(UA_LocalizedText)
 UA_TYPE_HANDLING_FUNCTIONS(UA_ExtensionObject)


### PR DESCRIPTION
Please review as I am a little uncertain about the changes to UA_StatusCode_new and UA_StatusCode_copy.

The following changes were made:
* Updated CMakeList.txt to reference updated output name
* Updated CMakeList.txt for Python and Lua library dependency
* Updated `bindings/open62541.i` to fix init warnings
* Cast `UA_INT64_(MAX/MIN)` and `UA_UINT64_(MAX/MIN)` to export with correct precision
* Changed `UA_NodeIdType` to be external enum for exporting
* Updated UA_StatusCode type handling functions