### PR TITLE
Update ua_subscription_manager.c

### DIFF
--- a/src/server/ua_subscription_manager.c
+++ b/src/server/ua_subscription_manager.c
@@ -62,8 +62,8 @@ void SubscriptionManager_addSubscription(UA_SubscriptionManager *manager, UA_Sub
 
 UA_Subscription *SubscriptionManager_getSubscriptionByID(UA_SubscriptionManager *manager,
                                                          UA_Int32 subscriptionID) {
-    UA_Subscription *sub;
-    LIST_FOREACH(sub, &manager->serverSubscriptions, listEntry) {
+    UA_Subscription *sub, *tmp_sub;
+    LIST_FOREACH_SAFE(sub, &manager->serverSubscriptions, listEntry, tmp_sub) {
         if(sub->subscriptionID == subscriptionID)
             break;
     }


### PR DESCRIPTION
SubscriptionManager_deleteSubscription call SubscriptionManager_getSubscriptionByID to remove the subscription but SubscriptionManager_getSubscriptionByID don't use LIST_FOREACH_SAFE