### PR TITLE
Update ua_subscription_manager.c

### DIFF
--- a/src/server/ua_subscription_manager.c
+++ b/src/server/ua_subscription_manager.c
@@ -76,10 +76,10 @@ UA_Int32 SubscriptionManager_deleteMonitoredItem(UA_SubscriptionManager *manager
     if(!sub)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     
-    UA_MonitoredItem *mon;
-    LIST_FOREACH(mon, &sub->MonitoredItems, listEntry) {
+    UA_MonitoredItem *mon, *tmp_mon;
+    LIST_FOREACH_SAFE(mon, &sub->MonitoredItems, listEntry, tmp_mon) {
         if (mon->itemId == monitoredItemID) {
-            // FIXME!! don't we need to remove the list entry?
+            LIST_REMOVE(mon, listEntry);
             MonitoredItem_delete(mon);
             return UA_STATUSCODE_GOOD;
         }


### PR DESCRIPTION
UA_Subscription_deleteMembers call LIST_FOREACH_SAFE before calling MonitoredItem_delete

    void UA_Subscription_deleteMembers(UA_Subscription *subscription, UA_Server *server) {
    UA_MonitoredItem *mon, *tmp_mon;
    
    // Just in case any parallel process attempts to access this subscription
    // while we are deleting it... make it vanish.
    subscription->subscriptionID = 0;
    
    // Delete monitored Items
    LIST_FOREACH_SAFE(mon, &subscription->MonitoredItems, listEntry, tmp_mon) {
        LIST_REMOVE(mon, listEntry);
        MonitoredItem_delete(mon);
    } 

I think SubscriptionManager_deleteMonitoredItem must do the same