### PR TITLE
using strtoul instead of atoi in networklayer_tcp

### DIFF
--- a/examples/networklayer_tcp.c
+++ b/examples/networklayer_tcp.c
@@ -498,7 +498,15 @@ ClientNetworkLayerTCP_connect(UA_ConnectionConfig localConf, char *endpointUrl, 
     UA_UInt16 port;
     for(port = 0; portpos < urlLength-1; portpos++) {
         if(endpointUrl[portpos] == ':') {
-            port = atoi(&endpointUrl[portpos+1]);
+            char *endPtr = NULL;
+            unsigned long int tempulong = strtoul(&endpointUrl[portpos+1], &endPtr, 10);
+            if (ERANGE != errno &&
+                tempulong < UINT16_MAX &&
+                tempulong > 0 &&
+                endPtr != &endpointUrl[portpos+1])
+            {
+                port = (UA_UInt16)tempulong;
+            }
             break;
         }
     }


### PR DESCRIPTION
refer to https://www.securecoding.cert.org/confluence/x/qoAyAQ